### PR TITLE
redraw the OpenGL window on refresh event

### DIFF
--- a/rai/Gui/opengl.cpp
+++ b/rai/Gui/opengl.cpp
@@ -376,6 +376,10 @@ struct GlfwSpinner : Thread {
     gl->Scroll(0, yoffset);
   }
 
+  static void _Refresh(GLFWwindow* window){
+    OpenGL* gl=(OpenGL*)glfwGetWindowUserPointer(window);
+    gl->postRedrawEvent(true);
+  }
 };
 
 static GlfwSpinner* singletonGlSpinner() {
@@ -405,6 +409,7 @@ void OpenGL::openWindow() {
     glfwSetScrollCallback(self->window, GlfwSpinner::_Scroll);
     glfwSetWindowSizeCallback(self->window, GlfwSpinner::_Resize);
     glfwSetWindowCloseCallback(self->window, GlfwSpinner::_Close);
+    glfwSetWindowRefreshCallback(self->window, GlfwSpinner::_Refresh);
 
     glfwSwapInterval(1);
     glfwMakeContextCurrent(nullptr);


### PR DESCRIPTION
Thank you for keeping this framework open source.
Your research is really valuable. :+1:

As documented [with glfw's callback method](https://www.glfw.org/docs/latest/group__window.html#ga1c5c7eb889c33c7f4d10dd35b327654e)
This patch is only relevant for non-compositing window managers
(compiz work well without it).

Without this patch the window does not redraw after it left
the screen and appears again. (It would redraw though after resizing it)